### PR TITLE
Fix mxint cast and add support for off by one mode in cocotb monitor

### DIFF
--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -148,9 +148,9 @@ module mxint_cast #(
   // Compute Shift Value
   // =============================
 
-  localparam SHIFT_WIDTH = max($clog2(OUT_MAN_WIDTH * 5), $clog2(LOSSLESSS_EDATA_WIDTH * 5), 0);
+  localparam SHIFT_WIDTH = max(LOSSLESSS_EDATA_WIDTH, IN_MAN_WIDTH, OUT_MAN_WIDTH) + 1;
   logic signed [SHIFT_WIDTH - 1:0] shift_value;
-  assign shift_value = $signed(edata_out_full - edata_out) + OUT_MAN_WIDTH - log2_max_value - 2;
+  assign shift_value = $signed(edata_out_full - edata_out) + $signed(OUT_MAN_WIDTH - log2_max_value - 2);
 
   // =============================
   // Compute Output Mantissa

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -150,7 +150,12 @@ module mxint_cast #(
 
   localparam SHIFT_WIDTH = max(LOSSLESSS_EDATA_WIDTH, IN_MAN_WIDTH, OUT_MAN_WIDTH) + 1;
   logic signed [SHIFT_WIDTH - 1:0] shift_value;
-  assign shift_value = $signed(edata_out_full - edata_out) + $signed(OUT_MAN_WIDTH - log2_max_value - 2);
+
+  assign shift_value = $signed(
+      edata_out_full - edata_out
+  ) + $signed(
+      OUT_MAN_WIDTH - log2_max_value - 2
+  );
 
   // =============================
   // Compute Output Mantissa

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -152,18 +152,6 @@ module mxint_cast #(
   logic signed [SHIFT_WIDTH - 1:0] shift_value;
   assign shift_value = $signed(edata_out_full - edata_out) + OUT_MAN_WIDTH - log2_max_value - 2;
 
-
-  always_comb begin
-    assert (shift_value == $signed(
-        $signed(edata_out_full - edata_out) + $signed(OUT_MAN_WIDTH - log2_max_value - 2)
-    ));
-    else $fatal("Shift value is not correct");
-    assert (edata_out_full == $signed(
-        log2_max_value - IN_MAN_WIDTH + 2 + ebuffer_data_for_out - EBIAS_IN + EBIAS_OUT
-    ))
-    else $fatal("Output exponent is not correct");
-  end
-
   // =============================
   // Compute Output Mantissa
   // =============================

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 
 # This script tests the fixed point linear
-import os, logging
+import os, logging, pytest
+
+import random
+import sys
+from mase_cocotb.utils import bit_driver
 
 import cocotb
 from cocotb.log import SimLog
@@ -42,31 +46,56 @@ class MXINTVectorMultTB(Testbench):
             dut.data_out_ready,
             check=True,
         )
+
         self.data_in_0_driver.log.setLevel(logging.DEBUG)
         self.data_out_0_monitor.log.setLevel(logging.DEBUG)
 
+    def generate_outputs(self, mdata_in, edata_in):
+        block_size = int(self.get_parameter("BLOCK_SIZE"))
+        mantissa_width_in = int(self.get_parameter("IN_MAN_WIDTH"))
+        exponent_width_in = int(self.get_parameter("IN_EXP_WIDTH"))
+        mantissa_width_out = int(self.get_parameter("OUT_MAN_WIDTH"))
+        exponent_width_out = int(self.get_parameter("OUT_EXP_WIDTH"))
+
+        data_in = torch.tensor(mdata_in, dtype=torch.float) * (
+            2 ** (2 - mantissa_width_in + edata_in - 2 ** (exponent_width_in - 1) + 1)
+        )
+        data_out, mdata_out, edata_out = mxint_quantize(
+            data_in, mantissa_width_out, exponent_width_out
+        )
+
+        mdata_out = mdata_out.int().tolist()
+        edata_out = edata_out.int().item()
+
+        bit_mask = 2 ** (exponent_width_out - 1) - 1
+        edata_out = (edata_out & bit_mask) - (edata_out & ~bit_mask)
+
+        return mdata_out, edata_out
+
     def generate_inputs(self):
+
+        block_size = int(self.get_parameter("BLOCK_SIZE"))
+        mantissa_width = int(self.get_parameter("IN_MAN_WIDTH"))
+        exponent_width = int(self.get_parameter("IN_EXP_WIDTH"))
+
         inputs = []
         exp_outputs = []
+
         for _ in range(self.num):
-            data = 20 * torch.rand(int(self.dut.BLOCK_SIZE))
-            (data_in, mdata_in, edata_in) = mxint_quantize(
-                data,
-                int(self.dut.IN_MAN_WIDTH),
-                int(self.dut.IN_EXP_WIDTH),
-            )
-            exp_out, mexp_out, eexp_out = mxint_quantize(
-                data_in,
-                int(self.dut.OUT_MAN_WIDTH),
-                int(self.dut.OUT_EXP_WIDTH),
-            )
+            mdata_in = [
+                random.randint(
+                    -(2 ** (mantissa_width - 1)) + 1, 2 ** (mantissa_width - 1) - 1
+                )
+                for _ in range(block_size)
+            ]
+            edata_in = random.randint(0, 2**exponent_width - 1)
 
-            eexp_out = eexp_out.int().item()
-            mask = 2 ** (int(self.dut.OUT_EXP_WIDTH) - 1)
-            eexp_out = (eexp_out & ~mask) - (eexp_out & mask)
+            inputs.append((mdata_in, edata_in))
 
-            inputs.append((mdata_in.int().tolist(), edata_in.int().tolist()))
-            exp_outputs.append(([int(mexp) for mexp in mexp_out.tolist()], eexp_out))
+            mdata_out, edata_out = self.generate_outputs(mdata_in, edata_in)
+
+            exp_outputs.append((mdata_out, edata_out))
+
         return inputs, exp_outputs
 
     async def run_test(self):
@@ -77,53 +106,82 @@ class MXINTVectorMultTB(Testbench):
         logger.info(f"generating inputs")
         inputs, exp_outputs = self.generate_inputs()
 
-        # Load the inputs driver
         self.data_in_0_driver.load_driver(inputs)
 
-        # Load the output monitor
         self.data_out_0_monitor.load_monitor(exp_outputs)
 
         await Timer(5, units="us")
         assert self.data_out_0_monitor.exp_queue.empty()
 
 
+def get_mxint_cast_config_random(seed, kwargs={}):
+    random.seed(seed)
+
+    BLOCK_SIZE = random.randint(1, 16)
+
+    MAX_MANTISSA = 16
+    MAX_EXPONENT = 6
+
+    in_man = random.randint(4, MAX_MANTISSA)
+    in_exp = random.randint(2, MAX_EXPONENT)
+
+    out_man = random.randint(4, MAX_MANTISSA)
+    out_exp = random.randint(2, MAX_EXPONENT)
+
+    config = {
+        "IN_MAN_WIDTH": in_man,
+        "IN_EXP_WIDTH": in_exp,
+        "OUT_MAN_WIDTH": out_man,
+        "OUT_EXP_WIDTH": out_exp,
+        "BLOCK_SIZE": BLOCK_SIZE,
+    }
+
+    config.update(kwargs)
+    return config
+
+
+@pytest.mark.dev
+def test_mxint_cast_random():
+    """
+    Fully randomized parameter testing.
+    """
+    torch.manual_seed(10)
+    seed = os.getenv("COCOTB_SEED")
+
+    # use this to fix a particular parameter value
+    param_override = {
+        # "IN_MAN_WIDTH": 10,
+        # "IN_EXP_WIDTH": 5,
+        # "OUT_MAN_WIDTH": 10,
+        # "OUT_EXP_WIDTH": 5,
+        # "BLOCK_SIZE": 4,
+    }
+
+    if seed is not None:
+        seed = int(seed)
+        mase_runner(
+            trace=True,
+            module_param_list=[get_mxint_cast_config_random(seed, param_override)],
+        )
+    else:
+        num_configs = int(os.getenv("NUM_CONFIGS", default=1))
+        base_seed = random.randrange(sys.maxsize)
+        mase_runner(
+            trace=True,
+            module_param_list=[
+                get_mxint_cast_config_random(base_seed + i, param_override)
+                for i in range(num_configs)
+            ],
+            jobs=min(num_configs, os.cpu_count() // 2),
+        )
+        print(f"Test seeds: \n{[(i,base_seed+i) for i in range(num_configs)]}")
+
+
 @cocotb.test()
 async def test(dut):
-    tb = MXINTVectorMultTB(dut, num=10)
+    tb = MXINTVectorMultTB(dut, num=100)
     await tb.run_test()
 
 
 if __name__ == "__main__":
-    mase_runner(
-        trace=True,
-        module_param_list=[
-            # {
-            #     "IN_MAN_WIDTH": 6,
-            #     "IN_EXP_WIDTH": 3,
-            #     "OUT_MAN_WIDTH": 12,
-            #     "OUT_EXP_WIDTH": 4,
-            #     "BLOCK_SIZE": 4,
-            # },
-            # {
-            #     "IN_MAN_WIDTH": 8,
-            #     "IN_EXP_WIDTH": 3,
-            #     "OUT_MAN_WIDTH": 8,
-            #     "OUT_EXP_WIDTH": 3,
-            #     "BLOCK_SIZE": 4,
-            # },
-            {
-                "IN_MAN_WIDTH": 8,
-                "IN_EXP_WIDTH": 4,
-                "OUT_MAN_WIDTH": 49,
-                "OUT_EXP_WIDTH": 5,
-                "BLOCK_SIZE": 4,
-            },
-            # {
-            #     "IN_MAN_WIDTH": 12,
-            #     "IN_EXP_WIDTH": 3,
-            #     "OUT_MAN_WIDTH": 8,
-            #     "OUT_EXP_WIDTH": 4,
-            #     "BLOCK_SIZE": 4,
-            # },
-        ],
-    )
+    test_mxint_cast_random()

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -45,6 +45,7 @@ class MXINTVectorMultTB(Testbench):
             dut.data_out_valid,
             dut.data_out_ready,
             check=True,
+            off_by_one=True,
         )
 
         self.data_in_0_driver.log.setLevel(logging.DEBUG)

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
@@ -235,12 +235,12 @@ def get_mxint_linear_config_random(seed, kwargs={}):
     MAX_EXPONENT = 6
 
     mantissas = [random.randint(3, MAX_MANTISSA) for _ in range(4)]
-    exps = [random.randint(2,min(m, MAX_EXPONENT)) for m in mantissas]
+    exps = [random.randint(2, min(m, MAX_EXPONENT)) for m in mantissas]
     mantissas[3] = max(mantissas[0], mantissas[1], mantissas[2]) + 1
     exps[3] = max(exps[0], exps[1], exps[2]) + 1
-    
+
     config = {
-        "HAS_BIAS": random.randint(0,1),
+        "HAS_BIAS": random.randint(0, 1),
         "DATA_IN_0_TENSOR_SIZE_DIM_0": IN_FEATURES,
         "DATA_IN_0_TENSOR_SIZE_DIM_1": BATCH_SIZE,
         "DATA_IN_0_PARALLELISM_DIM_0": BLOCK_SIZE,
@@ -296,19 +296,19 @@ def test_mxint_linear_full_random():
 
     # use this to fix a particular parameter value
     param_override = {
-                    "HAS_BIAS": 1,
-                    "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
-                    "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
-                    "DATA_IN_0_PARALLELISM_DIM_0": 2,
-                    "WEIGHT_TENSOR_SIZE_DIM_0": 4,
-                    "WEIGHT_TENSOR_SIZE_DIM_1": 4,
-                    "WEIGHT_PARALLELISM_DIM_0": 2,
-                    "WEIGHT_PARALLELISM_DIM_1": 2,
-                    "BIAS_TENSOR_SIZE_DIM_0": 4,
-                    "BIAS_PARALLELISM_DIM_0": 2,
-                    # "DATA_OUT_0_PRECISION_1": 8,
-                    # "DATA_OUT_0_PRECISION_0": 8,
-                }
+        "HAS_BIAS": 1,
+        "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
+        "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
+        "DATA_IN_0_PARALLELISM_DIM_0": 2,
+        "WEIGHT_TENSOR_SIZE_DIM_0": 4,
+        "WEIGHT_TENSOR_SIZE_DIM_1": 4,
+        "WEIGHT_PARALLELISM_DIM_0": 2,
+        "WEIGHT_PARALLELISM_DIM_1": 2,
+        "BIAS_TENSOR_SIZE_DIM_0": 4,
+        "BIAS_PARALLELISM_DIM_0": 2,
+        # "DATA_OUT_0_PRECISION_1": 8,
+        # "DATA_OUT_0_PRECISION_0": 8,
+    }
 
     if seed is not None:
         seed = int(seed)

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import random
+import sys
+from mase_cocotb.utils import bit_driver
 import os, pytest
 
 import torch
@@ -23,7 +26,9 @@ from utils import MXIntLinear
 
 
 class LinearTB(Testbench):
-    def __init__(self, dut) -> None:
+    def __init__(
+        self, dut, data_in_p=1.0, weight_p=1.0, bias_p=1.0, data_out_p=1.0
+    ) -> None:
         super().__init__(dut, dut.clk, dut.rst)
 
         if not hasattr(self, "log"):
@@ -36,15 +41,19 @@ class LinearTB(Testbench):
             dut.data_in_0_valid,
             dut.data_in_0_ready,
         )
+        self.data_in_0_driver.set_valid_prob(data_in_p)
+
         self.weight_driver = MultiSignalStreamDriver(
             dut.clk, (dut.mweight, dut.eweight), dut.weight_valid, dut.weight_ready
         )
+        self.weight_driver.set_valid_prob(weight_p)
 
         if self.get_parameter("HAS_BIAS") == 1:
             self.bias_driver = MultiSignalStreamDriver(
                 dut.clk, (dut.mbias, dut.ebias), dut.bias_valid, dut.bias_ready
             )
             self.bias_driver.log.setLevel(logging.DEBUG)
+            self.bias_driver.set_valid_prob(bias_p)
 
         self.data_out_0_monitor = MultiSignalStreamMonitor(
             dut.clk,
@@ -52,7 +61,9 @@ class LinearTB(Testbench):
             dut.data_out_0_valid,
             dut.data_out_0_ready,
             check=True,
+            signed=False,
         )
+        cocotb.start_soon(bit_driver(dut.data_out_0_ready, dut.clk, data_out_p))
 
         # Model
         self.model = MXIntLinear(
@@ -101,8 +112,11 @@ class LinearTB(Testbench):
         from utils import pack_tensor_to_mx_listed_chunk
 
         (qtensor, mtensor, etensor) = block_mxint_quant(tensor, config, parallelism)
+        # take the mod to get the unsigned representation of the number
+        mtensor = mtensor.remainder(2 ** config["width"])
         self.log.info(f"Mantissa Tensor: {mtensor}")
-        self.log.info(f"Exponenr Tensor: {etensor}")
+        self.log.info(f"Exponent Tensor: {etensor}")
+
         tensor_inputs = pack_tensor_to_mx_listed_chunk(mtensor, etensor, parallelism)
         return tensor_inputs
 
@@ -124,7 +138,7 @@ class LinearTB(Testbench):
 
         # * Load the inputs driver
         self.log.info(f"Processing inputs: {inputs}")
-        inputs = self.preprocess_tensor_for_mxint(
+        inputs_quant = self.preprocess_tensor_for_mxint(
             tensor=inputs,
             config={
                 "width": self.get_parameter("DATA_IN_0_PRECISION_0"),
@@ -135,12 +149,12 @@ class LinearTB(Testbench):
                 self.get_parameter("DATA_IN_0_PARALLELISM_DIM_0"),
             ],
         )
-        self.data_in_0_driver.load_driver(inputs)
-
+        self.data_in_0_driver.load_driver(inputs_quant)
+        self.log.info(f"processed inputs\n{inputs_quant}")
         # * Load the weights driver
         weights = self.model.weight
 
-        self.log.info(f"Processing weights: {weights}")
+        self.log.info(f"Processing weights:\n{weights}")
         weights = self.preprocess_tensor_for_mxint(
             tensor=weights,
             config={
@@ -152,6 +166,7 @@ class LinearTB(Testbench):
                 self.get_parameter("WEIGHT_PARALLELISM_DIM_0"),
             ],
         )
+        self.log.info(f"Processed weights:\n{weights}")
         self.weight_driver.load_driver(weights)
 
         # * Load the bias driver
@@ -192,18 +207,64 @@ class LinearTB(Testbench):
 
 @cocotb.test()
 async def cocotb_test(dut):
-    tb = LinearTB(dut)
-    await tb.run_test(us=100)
+    probs = [torch.rand(1).item() for _ in range(4)]
+    # probs = [1 for _ in range(4)]
+    tb = LinearTB(
+        dut,
+        data_in_p=probs[0],
+        weight_p=probs[1],
+        bias_p=probs[2],
+        data_out_p=probs[3],
+    )
+    await tb.run_test(us=200)
 
 
-def get_fixed_linear_config(kwargs={}):
-    # if pretranspose
-    #   weight1 = in0
-    # else
-    #   weight0 = in0
-    # currently, we only consider the transposed situation
+def get_mxint_linear_config_random(seed, kwargs={}):
+    MAX_IN_FEATURES = 6
+    MAX_OUT_FEATURES = 6
+    MAX_BATCH_SIZE = 10
+    random.seed(seed)
+
+    BLOCK_SIZE = random.randint(2, 3)
+    PARALLELISM = random.randint(2, 2)
+    BATCH_SIZE = random.randint(2, MAX_BATCH_SIZE // PARALLELISM) * PARALLELISM
+    IN_FEATURES = random.randint(2, MAX_IN_FEATURES // BLOCK_SIZE) * BLOCK_SIZE
+    OUT_FEATURES = random.randint(2, MAX_OUT_FEATURES // BLOCK_SIZE) * BLOCK_SIZE
+
+    MAX_MANTISSA = 16
+    MAX_EXPONENT = 6
+
+    mantissas = [random.randint(3, MAX_MANTISSA) for _ in range(4)]
+    exps = [random.randint(2,min(m, MAX_EXPONENT)) for m in mantissas]
+    mantissas[3] = max(mantissas[0], mantissas[1], mantissas[2]) + 1
+    exps[3] = max(exps[0], exps[1], exps[2]) + 1
+    
     config = {
-        "HAS_BIAS": 0,
+        "HAS_BIAS": random.randint(0,1),
+        "DATA_IN_0_TENSOR_SIZE_DIM_0": IN_FEATURES,
+        "DATA_IN_0_TENSOR_SIZE_DIM_1": BATCH_SIZE,
+        "DATA_IN_0_PARALLELISM_DIM_0": BLOCK_SIZE,
+        "DATA_IN_0_PARALLELISM_DIM_1": PARALLELISM,
+        "WEIGHT_TENSOR_SIZE_DIM_0": IN_FEATURES,
+        "WEIGHT_TENSOR_SIZE_DIM_1": OUT_FEATURES,
+        "WEIGHT_PARALLELISM_DIM_0": BLOCK_SIZE,
+        "WEIGHT_PARALLELISM_DIM_1": BLOCK_SIZE,
+        "DATA_IN_0_PRECISION_0": mantissas[0],
+        "DATA_IN_0_PRECISION_1": exps[0],
+        "WEIGHT_PRECISION_0": mantissas[1],
+        "WEIGHT_PRECISION_1": exps[1],
+        "BIAS_PRECISION_0": mantissas[2],
+        "BIAS_PRECISION_1": exps[2],
+        "DATA_OUT_0_PRECISION_0": mantissas[3],
+        "DATA_OUT_0_PRECISION_1": exps[3],
+    }
+    config.update(kwargs)
+    return config
+
+
+def get_mxint_linear_config(kwargs={}):
+    config = {
+        "HAS_BIAS": 1,
         "DATA_IN_0_TENSOR_SIZE_DIM_0": 2,
         "DATA_IN_0_TENSOR_SIZE_DIM_1": 2,
         "DATA_IN_0_PARALLELISM_DIM_0": 2,
@@ -221,63 +282,64 @@ def get_fixed_linear_config(kwargs={}):
         "DATA_OUT_0_PRECISION_0": 10,
         "DATA_OUT_0_PRECISION_1": 4,
     }
-    # config = {
-    #     "HAS_BIAS": 1,
-    #     "DATA_IN_0_TENSOR_SIZE_DIM_0": 32,
-    #     "DATA_IN_0_TENSOR_SIZE_DIM_1": 16,
-    #     "DATA_IN_0_PARALLELISM_DIM_0": 4,
-    #     "DATA_IN_0_PARALLELISM_DIM_1": 4,
-    #     "WEIGHT_TENSOR_SIZE_DIM_0": 32,
-    #     "WEIGHT_TENSOR_SIZE_DIM_1": 16,
-    #     "WEIGHT_PARALLELISM_DIM_0": 4,
-    #     "WEIGHT_PARALLELISM_DIM_1": 4,
-    #     "DATA_IN_0_PRECISION_0": 9,
-    #     "DATA_IN_0_PRECISION_1": 4,
-    #     "WEIGHT_PRECISION_0": 8,
-    #     "WEIGHT_PRECISION_1": 3,
-    #     "BIAS_PRECISION_0": 8,
-    #     "BIAS_PRECISION_1": 4,
-    #     "DATA_OUT_0_PRECISION_0": 12,
-    #     "DATA_OUT_0_PRECISION_1": 4,
-    # }
     config.update(kwargs)
     return config
 
 
 @pytest.mark.dev
-def test_fixed_linear_smoke():
+def test_mxint_linear_full_random():
     """
-    Some quick tests to check if the module is working.
+    Fully randomized parameter testing.
     """
-    mase_runner(
-        trace=True,
-        module_param_list=[
-            get_fixed_linear_config(),
-            # noticed here if change WEIGHT_PRE_TRANSPOSED also need to change the DIM_SIZE to match ACTIVATION
-            # get_fixed_linear_config(
-            #     {
-            #         "WEIGHT_TENSOR_SIZE_DIM_0": 32,
-            #         "WEIGHT_TENSOR_SIZE_DIM_1": 16,
-            #         "WEIGHT_PARALLELISM_DIM_0": 4,
-            #         "WEIGHT_PARALLELISM_DIM_1": 2,
-            #     },
-            # ),
-        ],
-    )
+    torch.manual_seed(10)
+    seed = os.getenv("COCOTB_SEED")
+
+    # use this to fix a particular parameter value
+    param_override = {
+                    "HAS_BIAS": 1,
+                    "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
+                    "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
+                    "DATA_IN_0_PARALLELISM_DIM_0": 2,
+                    "WEIGHT_TENSOR_SIZE_DIM_0": 4,
+                    "WEIGHT_TENSOR_SIZE_DIM_1": 4,
+                    "WEIGHT_PARALLELISM_DIM_0": 2,
+                    "WEIGHT_PARALLELISM_DIM_1": 2,
+                    "BIAS_TENSOR_SIZE_DIM_0": 4,
+                    "BIAS_PARALLELISM_DIM_0": 2,
+                    # "DATA_OUT_0_PRECISION_1": 8,
+                    # "DATA_OUT_0_PRECISION_0": 8,
+                }
+
+    if seed is not None:
+        seed = int(seed)
+        mase_runner(
+            trace=True,
+            module_param_list=[get_mxint_linear_config_random(seed, param_override)],
+        )
+    else:
+        num_configs = int(os.getenv("NUM_CONFIGS", default=5))
+        base_seed = random.randrange(sys.maxsize)
+        mase_runner(
+            trace=True,
+            module_param_list=[
+                get_mxint_linear_config_random(base_seed + i, param_override)
+                for i in range(num_configs)
+            ],
+            jobs=min(num_configs, 10),
+        )
+        print(f"Test seeds: \n{[(i,base_seed+i) for i in range(num_configs)]}")
 
 
 @pytest.mark.dev
-def test_fixed_linear_regression():
-    """
-    More extensive tests to check realistic parameter sizes.
-    """
+def test_mxint_linear():
     mase_runner(
         trace=True,
         module_param_list=[
-            get_fixed_linear_config(
+            get_mxint_linear_config(
                 {
-                    "HAS_BIAS": 0,
+                    "HAS_BIAS": 1,
                     "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
+                    "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
                     "DATA_IN_0_PARALLELISM_DIM_0": 2,
                     "WEIGHT_TENSOR_SIZE_DIM_0": 4,
                     "WEIGHT_TENSOR_SIZE_DIM_1": 4,
@@ -287,23 +349,10 @@ def test_fixed_linear_regression():
                     "BIAS_PARALLELISM_DIM_0": 2,
                 }
             ),
-            # get_fixed_linear_config(
-            #     {
-            #         "HAS_BIAS": 1,
-            #         "DATA_IN_0_TENSOR_SIZE_DIM_0": 768,
-            #         "DATA_IN_0_PARALLELISM_DIM_0": 32,
-            #         "WEIGHT_TENSOR_SIZE_DIM_0": 768,
-            #         "WEIGHT_TENSOR_SIZE_DIM_1": 768,
-            #         "WEIGHT_PARALLELISM_DIM_0": 32,
-            #         "WEIGHT_PARALLELISM_DIM_1": 32,
-            #         "BIAS_TENSOR_SIZE_DIM_0": 768,
-            #         "BIAS_PARALLELISM_DIM_0": 32,
-            #     }
-            # ),
         ],
     )
 
 
 if __name__ == "__main__":
-    # test_fixed_linear_smoke()
-    test_fixed_linear_regression()
+    # test_mxint_linear()
+    test_mxint_linear_full_random()

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-import random
-import sys
-from mase_cocotb.utils import bit_driver
 import os, pytest
 
 import torch
@@ -26,9 +23,7 @@ from utils import MXIntLinear
 
 
 class LinearTB(Testbench):
-    def __init__(
-        self, dut, data_in_p=1.0, weight_p=1.0, bias_p=1.0, data_out_p=1.0
-    ) -> None:
+    def __init__(self, dut) -> None:
         super().__init__(dut, dut.clk, dut.rst)
 
         if not hasattr(self, "log"):
@@ -41,19 +36,15 @@ class LinearTB(Testbench):
             dut.data_in_0_valid,
             dut.data_in_0_ready,
         )
-        self.data_in_0_driver.set_valid_prob(data_in_p)
-
         self.weight_driver = MultiSignalStreamDriver(
             dut.clk, (dut.mweight, dut.eweight), dut.weight_valid, dut.weight_ready
         )
-        self.weight_driver.set_valid_prob(weight_p)
 
         if self.get_parameter("HAS_BIAS") == 1:
             self.bias_driver = MultiSignalStreamDriver(
                 dut.clk, (dut.mbias, dut.ebias), dut.bias_valid, dut.bias_ready
             )
             self.bias_driver.log.setLevel(logging.DEBUG)
-            self.bias_driver.set_valid_prob(bias_p)
 
         self.data_out_0_monitor = MultiSignalStreamMonitor(
             dut.clk,
@@ -61,9 +52,7 @@ class LinearTB(Testbench):
             dut.data_out_0_valid,
             dut.data_out_0_ready,
             check=True,
-            signed=False,
         )
-        cocotb.start_soon(bit_driver(dut.data_out_0_ready, dut.clk, data_out_p))
 
         # Model
         self.model = MXIntLinear(
@@ -112,11 +101,8 @@ class LinearTB(Testbench):
         from utils import pack_tensor_to_mx_listed_chunk
 
         (qtensor, mtensor, etensor) = block_mxint_quant(tensor, config, parallelism)
-        # take the mod to get the unsigned representation of the number
-        mtensor = mtensor.remainder(2 ** config["width"])
         self.log.info(f"Mantissa Tensor: {mtensor}")
-        self.log.info(f"Exponent Tensor: {etensor}")
-
+        self.log.info(f"Exponenr Tensor: {etensor}")
         tensor_inputs = pack_tensor_to_mx_listed_chunk(mtensor, etensor, parallelism)
         return tensor_inputs
 
@@ -138,7 +124,7 @@ class LinearTB(Testbench):
 
         # * Load the inputs driver
         self.log.info(f"Processing inputs: {inputs}")
-        inputs_quant = self.preprocess_tensor_for_mxint(
+        inputs = self.preprocess_tensor_for_mxint(
             tensor=inputs,
             config={
                 "width": self.get_parameter("DATA_IN_0_PRECISION_0"),
@@ -149,12 +135,12 @@ class LinearTB(Testbench):
                 self.get_parameter("DATA_IN_0_PARALLELISM_DIM_0"),
             ],
         )
-        self.data_in_0_driver.load_driver(inputs_quant)
-        self.log.info(f"processed inputs\n{inputs_quant}")
+        self.data_in_0_driver.load_driver(inputs)
+
         # * Load the weights driver
         weights = self.model.weight
 
-        self.log.info(f"Processing weights:\n{weights}")
+        self.log.info(f"Processing weights: {weights}")
         weights = self.preprocess_tensor_for_mxint(
             tensor=weights,
             config={
@@ -166,7 +152,6 @@ class LinearTB(Testbench):
                 self.get_parameter("WEIGHT_PARALLELISM_DIM_0"),
             ],
         )
-        self.log.info(f"Processed weights:\n{weights}")
         self.weight_driver.load_driver(weights)
 
         # * Load the bias driver
@@ -207,64 +192,18 @@ class LinearTB(Testbench):
 
 @cocotb.test()
 async def cocotb_test(dut):
-    probs = [torch.rand(1).item() for _ in range(4)]
-    # probs = [1 for _ in range(4)]
-    tb = LinearTB(
-        dut,
-        data_in_p=probs[0],
-        weight_p=probs[1],
-        bias_p=probs[2],
-        data_out_p=probs[3],
-    )
-    await tb.run_test(us=200)
+    tb = LinearTB(dut)
+    await tb.run_test(us=100)
 
 
-def get_mxint_linear_config_random(seed, kwargs={}):
-    MAX_IN_FEATURES = 6
-    MAX_OUT_FEATURES = 6
-    MAX_BATCH_SIZE = 10
-    random.seed(seed)
-
-    BLOCK_SIZE = random.randint(2, 3)
-    PARALLELISM = random.randint(2, 2)
-    BATCH_SIZE = random.randint(2, MAX_BATCH_SIZE // PARALLELISM) * PARALLELISM
-    IN_FEATURES = random.randint(2, MAX_IN_FEATURES // BLOCK_SIZE) * BLOCK_SIZE
-    OUT_FEATURES = random.randint(2, MAX_OUT_FEATURES // BLOCK_SIZE) * BLOCK_SIZE
-
-    MAX_MANTISSA = 16
-    MAX_EXPONENT = 6
-
-    mantissas = [random.randint(3, MAX_MANTISSA) for _ in range(4)]
-    exps = [random.randint(2, min(m, MAX_EXPONENT)) for m in mantissas]
-    mantissas[3] = max(mantissas[0], mantissas[1], mantissas[2]) + 1
-    exps[3] = max(exps[0], exps[1], exps[2]) + 1
-
+def get_fixed_linear_config(kwargs={}):
+    # if pretranspose
+    #   weight1 = in0
+    # else
+    #   weight0 = in0
+    # currently, we only consider the transposed situation
     config = {
-        "HAS_BIAS": random.randint(0, 1),
-        "DATA_IN_0_TENSOR_SIZE_DIM_0": IN_FEATURES,
-        "DATA_IN_0_TENSOR_SIZE_DIM_1": BATCH_SIZE,
-        "DATA_IN_0_PARALLELISM_DIM_0": BLOCK_SIZE,
-        "DATA_IN_0_PARALLELISM_DIM_1": PARALLELISM,
-        "WEIGHT_TENSOR_SIZE_DIM_0": IN_FEATURES,
-        "WEIGHT_TENSOR_SIZE_DIM_1": OUT_FEATURES,
-        "WEIGHT_PARALLELISM_DIM_0": BLOCK_SIZE,
-        "WEIGHT_PARALLELISM_DIM_1": BLOCK_SIZE,
-        "DATA_IN_0_PRECISION_0": mantissas[0],
-        "DATA_IN_0_PRECISION_1": exps[0],
-        "WEIGHT_PRECISION_0": mantissas[1],
-        "WEIGHT_PRECISION_1": exps[1],
-        "BIAS_PRECISION_0": mantissas[2],
-        "BIAS_PRECISION_1": exps[2],
-        "DATA_OUT_0_PRECISION_0": mantissas[3],
-        "DATA_OUT_0_PRECISION_1": exps[3],
-    }
-    config.update(kwargs)
-    return config
-
-
-def get_mxint_linear_config(kwargs={}):
-    config = {
-        "HAS_BIAS": 1,
+        "HAS_BIAS": 0,
         "DATA_IN_0_TENSOR_SIZE_DIM_0": 2,
         "DATA_IN_0_TENSOR_SIZE_DIM_1": 2,
         "DATA_IN_0_PARALLELISM_DIM_0": 2,
@@ -282,64 +221,63 @@ def get_mxint_linear_config(kwargs={}):
         "DATA_OUT_0_PRECISION_0": 10,
         "DATA_OUT_0_PRECISION_1": 4,
     }
+    # config = {
+    #     "HAS_BIAS": 1,
+    #     "DATA_IN_0_TENSOR_SIZE_DIM_0": 32,
+    #     "DATA_IN_0_TENSOR_SIZE_DIM_1": 16,
+    #     "DATA_IN_0_PARALLELISM_DIM_0": 4,
+    #     "DATA_IN_0_PARALLELISM_DIM_1": 4,
+    #     "WEIGHT_TENSOR_SIZE_DIM_0": 32,
+    #     "WEIGHT_TENSOR_SIZE_DIM_1": 16,
+    #     "WEIGHT_PARALLELISM_DIM_0": 4,
+    #     "WEIGHT_PARALLELISM_DIM_1": 4,
+    #     "DATA_IN_0_PRECISION_0": 9,
+    #     "DATA_IN_0_PRECISION_1": 4,
+    #     "WEIGHT_PRECISION_0": 8,
+    #     "WEIGHT_PRECISION_1": 3,
+    #     "BIAS_PRECISION_0": 8,
+    #     "BIAS_PRECISION_1": 4,
+    #     "DATA_OUT_0_PRECISION_0": 12,
+    #     "DATA_OUT_0_PRECISION_1": 4,
+    # }
     config.update(kwargs)
     return config
 
 
 @pytest.mark.dev
-def test_mxint_linear_full_random():
+def test_fixed_linear_smoke():
     """
-    Fully randomized parameter testing.
+    Some quick tests to check if the module is working.
     """
-    torch.manual_seed(10)
-    seed = os.getenv("COCOTB_SEED")
-
-    # use this to fix a particular parameter value
-    param_override = {
-        "HAS_BIAS": 1,
-        "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
-        "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
-        "DATA_IN_0_PARALLELISM_DIM_0": 2,
-        "WEIGHT_TENSOR_SIZE_DIM_0": 4,
-        "WEIGHT_TENSOR_SIZE_DIM_1": 4,
-        "WEIGHT_PARALLELISM_DIM_0": 2,
-        "WEIGHT_PARALLELISM_DIM_1": 2,
-        "BIAS_TENSOR_SIZE_DIM_0": 4,
-        "BIAS_PARALLELISM_DIM_0": 2,
-        # "DATA_OUT_0_PRECISION_1": 8,
-        # "DATA_OUT_0_PRECISION_0": 8,
-    }
-
-    if seed is not None:
-        seed = int(seed)
-        mase_runner(
-            trace=True,
-            module_param_list=[get_mxint_linear_config_random(seed, param_override)],
-        )
-    else:
-        num_configs = int(os.getenv("NUM_CONFIGS", default=5))
-        base_seed = random.randrange(sys.maxsize)
-        mase_runner(
-            trace=True,
-            module_param_list=[
-                get_mxint_linear_config_random(base_seed + i, param_override)
-                for i in range(num_configs)
-            ],
-            jobs=min(num_configs, 10),
-        )
-        print(f"Test seeds: \n{[(i,base_seed+i) for i in range(num_configs)]}")
-
-
-@pytest.mark.dev
-def test_mxint_linear():
     mase_runner(
         trace=True,
         module_param_list=[
-            get_mxint_linear_config(
+            get_fixed_linear_config(),
+            # noticed here if change WEIGHT_PRE_TRANSPOSED also need to change the DIM_SIZE to match ACTIVATION
+            # get_fixed_linear_config(
+            #     {
+            #         "WEIGHT_TENSOR_SIZE_DIM_0": 32,
+            #         "WEIGHT_TENSOR_SIZE_DIM_1": 16,
+            #         "WEIGHT_PARALLELISM_DIM_0": 4,
+            #         "WEIGHT_PARALLELISM_DIM_1": 2,
+            #     },
+            # ),
+        ],
+    )
+
+
+@pytest.mark.dev
+def test_fixed_linear_regression():
+    """
+    More extensive tests to check realistic parameter sizes.
+    """
+    mase_runner(
+        trace=True,
+        module_param_list=[
+            get_fixed_linear_config(
                 {
-                    "HAS_BIAS": 1,
+                    "HAS_BIAS": 0,
                     "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
-                    "DATA_IN_0_TENSOR_SIZE_DIM_1": 10,
                     "DATA_IN_0_PARALLELISM_DIM_0": 2,
                     "WEIGHT_TENSOR_SIZE_DIM_0": 4,
                     "WEIGHT_TENSOR_SIZE_DIM_1": 4,
@@ -349,10 +287,23 @@ def test_mxint_linear():
                     "BIAS_PARALLELISM_DIM_0": 2,
                 }
             ),
+            # get_fixed_linear_config(
+            #     {
+            #         "HAS_BIAS": 1,
+            #         "DATA_IN_0_TENSOR_SIZE_DIM_0": 768,
+            #         "DATA_IN_0_PARALLELISM_DIM_0": 32,
+            #         "WEIGHT_TENSOR_SIZE_DIM_0": 768,
+            #         "WEIGHT_TENSOR_SIZE_DIM_1": 768,
+            #         "WEIGHT_PARALLELISM_DIM_0": 32,
+            #         "WEIGHT_PARALLELISM_DIM_1": 32,
+            #         "BIAS_TENSOR_SIZE_DIM_0": 768,
+            #         "BIAS_PARALLELISM_DIM_0": 32,
+            #     }
+            # ),
         ],
     )
 
 
 if __name__ == "__main__":
-    # test_mxint_linear()
-    test_mxint_linear_full_random()
+    # test_fixed_linear_smoke()
+    test_fixed_linear_regression()


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and testing of the `mxint_cast` modules. The most important changes include adding an `off_by_one` parameter to the `MultiSignalStreamMonitor`, modifying the `mxint_cast` module's internal logic, and enhancing the test scripts for both modules.

### Enhancements to `MultiSignalStreamMonitor`:

* [`src/mase_cocotb/interfaces/streaming.py`](diffhunk://#diff-d956b4d79379a0b2d9aa1227290f5995f11020db730f6ee503852807389402d7L276-R286): Added an `off_by_one` parameter to the `MultiSignalStreamMonitor` class to allow for off-by-one error checking in the `_check` method. [[1]](diffhunk://#diff-d956b4d79379a0b2d9aa1227290f5995f11020db730f6ee503852807389402d7L276-R286) [[2]](diffhunk://#diff-d956b4d79379a0b2d9aa1227290f5995f11020db730f6ee503852807389402d7R309-R312)

### Modifications to `mxint_cast` module:

* [`src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv`](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3L32-R37): Changed internal signal definitions to signed logic, added new local parameters for data bounds, and updated the shift value computation and output mantissa calculation logic. [[1]](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3L32-R37) [[2]](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3L50-R52) [[3]](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3R136) [[4]](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3L149-R153) [[5]](diffhunk://#diff-258bba66ad23fcc4663a5aa6689740b7f55515002b29cdb8e7cea9b2ea62b3d3L162-R181)

### Enhancements to test scripts:

* [`src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py`](diffhunk://#diff-b2863f4c564bda4107983b190fbb0cc287b292af2f09a6da6496c8d7c810e76dL4-R8): Added new methods for generating inputs and outputs, implemented randomized parameter testing using `pytest`, and updated the test configuration and execution logic. [[1]](diffhunk://#diff-b2863f4c564bda4107983b190fbb0cc287b292af2f09a6da6496c8d7c810e76dL4-R8) [[2]](diffhunk://#diff-b2863f4c564bda4107983b190fbb0cc287b292af2f09a6da6496c8d7c810e76dR48-L69) [[3]](diffhunk://#diff-b2863f4c564bda4107983b190fbb0cc287b292af2f09a6da6496c8d7c810e76dL80-R188)