### PR TITLE
Feat add relu

### DIFF
--- a/src/mase_components/deps.py
+++ b/src/mase_components/deps.py
@@ -278,6 +278,13 @@ MASE_HW_DEPS = {
         "memory",
         "cast",
     ],
+    "linear_layers/mxint_operators/mxint_relu": [
+        "linear_layers/mxint_operators",
+        "linear_layers/fixed_operators",
+        "common",
+        "memory",
+        "cast",
+    ],
     "linear_layers/mxint_operators/mxint_cast": [
         "linear_layers/mxint_operators",
         "linear_layers/fixed_operators",

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_relu.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_relu.sv
@@ -37,40 +37,38 @@ module mxint_relu #(
     input logic data_out_0_ready
 
 );
-    logic [DATA_IN_0_PRECISION_0-1:0] mdata_out_0_i [DATA_IN_0_PARALLELISM_DIM_0*DATA_IN_0_PARALLELISM_DIM_1-1:0];
-    logic [DATA_IN_0_PRECISION_1-1:0] edata_out_0_i;
-    logic data_out_0_valid_i;
-    logic data_out_0_ready_i;
+  logic [DATA_IN_0_PRECISION_0-1:0] mdata_out_0_i [DATA_IN_0_PARALLELISM_DIM_0*DATA_IN_0_PARALLELISM_DIM_1-1:0];
+  logic [DATA_IN_0_PRECISION_1-1:0] edata_out_0_i;
+  logic data_out_0_valid_i;
+  logic data_out_0_ready_i;
 
-    always_comb
-    begin
-        edata_out_0_i         = edata_in_0;
+  always_comb begin
+    edata_out_0_i = edata_in_0;
 
-        for (int i = 0; i < DATA_IN_0_PARALLELISM_DIM_0 * DATA_IN_0_PARALLELISM_DIM_1; i++)
-        begin
-            mdata_out_0_i[i]  = mdata_in_0[i][DATA_IN_0_PRECISION_0-1] ? '0 : mdata_in_0[i];
-        end
-        data_out_0_valid_i    = data_in_0_valid;
+    for (int i = 0; i < DATA_IN_0_PARALLELISM_DIM_0 * DATA_IN_0_PARALLELISM_DIM_1; i++) begin
+      mdata_out_0_i[i] = mdata_in_0[i][DATA_IN_0_PRECISION_0-1] ? '0 : mdata_in_0[i];
     end
+    data_out_0_valid_i = data_in_0_valid;
+  end
 
-    mxint_cast #(
-      .IN_MAN_WIDTH     (DATA_IN_0_PRECISION_0),
-      .IN_EXP_WIDTH     (DATA_IN_0_PRECISION_1),
-      .OUT_MAN_WIDTH    (DATA_IN_0_PRECISION_0),
-      .OUT_EXP_WIDTH    (DATA_IN_0_PRECISION_1),
-      .BLOCK_SIZE       (DATA_IN_0_PARALLELISM_DIM_1 * DATA_IN_0_PARALLELISM_DIM_0)
-    ) cast_i            (
-        .clk            (clk),
-        .rst            (rst),
-        .mdata_in       (mdata_out_0_i),
-        .edata_in       (edata_out_0_i),
-        .data_in_valid  (data_out_0_valid_i),
-        .data_in_ready  (data_in_0_ready),
-        .mdata_out      (mdata_out_0),
-        .edata_out      (edata_out_0),
-        .data_out_valid (data_out_0_valid),
-        .data_out_ready (data_out_0_ready)
-    );
+  mxint_cast #(
+      .IN_MAN_WIDTH (DATA_IN_0_PRECISION_0),
+      .IN_EXP_WIDTH (DATA_IN_0_PRECISION_1),
+      .OUT_MAN_WIDTH(DATA_IN_0_PRECISION_0),
+      .OUT_EXP_WIDTH(DATA_IN_0_PRECISION_1),
+      .BLOCK_SIZE   (DATA_IN_0_PARALLELISM_DIM_1 * DATA_IN_0_PARALLELISM_DIM_0)
+  ) cast_i (
+      .clk           (clk),
+      .rst           (rst),
+      .mdata_in      (mdata_out_0_i),
+      .edata_in      (edata_out_0_i),
+      .data_in_valid (data_out_0_valid_i),
+      .data_in_ready (data_in_0_ready),
+      .mdata_out     (mdata_out_0),
+      .edata_out     (edata_out_0),
+      .data_out_valid(data_out_0_valid),
+      .data_out_ready(data_out_0_ready)
+  );
 
 endmodule
 

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_relu.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_relu.sv
@@ -1,0 +1,76 @@
+/*
+Module      : mxint_relu
+Description : This module performs relu(x) on the input function
+
+              Python equivalent:
+              out = torch.nn.functional.relu(x)
+
+              x should be the dimension of (DATA_IN_0_TENSOR_SIZE_DIM_1, DATA_IN_0_TENSOR_SIZE_DIM_0)
+*/
+`timescale 1ns / 1ps
+
+module mxint_relu #(
+    /* verilator lint_off UNUSEDPARAM */
+    parameter HAS_BIAS = 1,
+
+    parameter DATA_IN_0_PRECISION_0 = 16,
+    parameter DATA_IN_0_PRECISION_1 = 3,
+    parameter DATA_IN_0_TENSOR_SIZE_DIM_0 = 20,
+    parameter DATA_IN_0_TENSOR_SIZE_DIM_1 = 20,
+    parameter DATA_IN_0_PARALLELISM_DIM_0 = 4,  // must equal WEIGHT_PARALLELISM_DIM_1
+    parameter DATA_IN_0_PARALLELISM_DIM_1 = 4,
+
+    localparam IN_0_DEPTH_DIM_0 = DATA_IN_0_TENSOR_SIZE_DIM_0 / DATA_IN_0_PARALLELISM_DIM_0,
+    localparam IN_0_DEPTH_DIM_1 = DATA_IN_0_TENSOR_SIZE_DIM_1 / DATA_IN_0_PARALLELISM_DIM_1
+) (
+    input clk,
+    input rst,
+
+    input logic [DATA_IN_0_PRECISION_0-1:0] mdata_in_0 [DATA_IN_0_PARALLELISM_DIM_0*DATA_IN_0_PARALLELISM_DIM_1-1:0],
+    input logic [DATA_IN_0_PRECISION_1-1:0] edata_in_0,
+    input logic data_in_0_valid,
+    output logic data_in_0_ready,
+
+    output logic [DATA_IN_0_PRECISION_0-1:0] mdata_out_0 [DATA_IN_0_PARALLELISM_DIM_0*DATA_IN_0_PARALLELISM_DIM_1-1:0],
+    output logic [DATA_IN_0_PRECISION_1-1:0] edata_out_0,
+    output logic data_out_0_valid,
+    input logic data_out_0_ready
+
+);
+    logic [DATA_IN_0_PRECISION_0-1:0] mdata_out_0_i [DATA_IN_0_PARALLELISM_DIM_0*DATA_IN_0_PARALLELISM_DIM_1-1:0];
+    logic [DATA_IN_0_PRECISION_1-1:0] edata_out_0_i;
+    logic data_out_0_valid_i;
+    logic data_out_0_ready_i;
+
+    always_comb
+    begin
+        edata_out_0_i         = edata_in_0;
+
+        for (int i = 0; i < DATA_IN_0_PARALLELISM_DIM_0 * DATA_IN_0_PARALLELISM_DIM_1; i++)
+        begin
+            mdata_out_0_i[i]  = mdata_in_0[i][DATA_IN_0_PRECISION_0-1] ? '0 : mdata_in_0[i];
+        end
+        data_out_0_valid_i    = data_in_0_valid;
+    end
+
+    mxint_cast #(
+      .IN_MAN_WIDTH     (DATA_IN_0_PRECISION_0),
+      .IN_EXP_WIDTH     (DATA_IN_0_PRECISION_1),
+      .OUT_MAN_WIDTH    (DATA_IN_0_PRECISION_0),
+      .OUT_EXP_WIDTH    (DATA_IN_0_PRECISION_1),
+      .BLOCK_SIZE       (DATA_IN_0_PARALLELISM_DIM_1 * DATA_IN_0_PARALLELISM_DIM_0)
+    ) cast_i            (
+        .clk            (clk),
+        .rst            (rst),
+        .mdata_in       (mdata_out_0_i),
+        .edata_in       (edata_out_0_i),
+        .data_in_valid  (data_out_0_valid_i),
+        .data_in_ready  (data_in_0_ready),
+        .mdata_out      (mdata_out_0),
+        .edata_out      (edata_out_0),
+        .data_out_valid (data_out_0_valid),
+        .data_out_ready (data_out_0_ready)
+    );
+
+endmodule
+

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_relu_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_relu_tb.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+import os, pytest
+
+import torch
+import logging
+from functools import partial
+
+import cocotb
+from cocotb.log import SimLog
+from cocotb.triggers import Timer, RisingEdge
+
+from mase_cocotb.testbench import Testbench
+from mase_cocotb.interfaces.streaming import (
+    MultiSignalStreamDriver,
+    MultiSignalStreamMonitor,
+)
+from mase_cocotb.runner import mase_runner
+
+torch.manual_seed(0)
+# from mase_cocotb import Testbench, StreamDriver, StreamMonitor, mase_runner
+from utils import MXIntRelu
+
+class MXIntReluTB(Testbench):
+    def __init__(self, dut) -> None:
+        super().__init__(dut, dut.clk, dut.rst)
+
+        if not hasattr(self, "log"):
+            self.log = SimLog("%s" % (type(self).__qualname__))
+            self.log.setLevel(logging.DEBUG)
+
+        self.data_in_0_driver = MultiSignalStreamDriver(
+            dut.clk,
+            (dut.mdata_in_0, dut.edata_in_0),
+            dut.data_in_0_valid,
+            dut.data_in_0_ready,
+        )
+
+        self.data_out_0_monitor = MultiSignalStreamMonitor(
+            dut.clk,
+            (dut.mdata_out_0, dut.edata_out_0),
+            dut.data_out_0_valid,
+            dut.data_out_0_ready,
+            check=True,
+        )
+
+        # Model
+        self.model = MXIntRelu(
+            config={
+                "data_in_width": self.get_parameter("DATA_IN_0_PRECISION_0"),
+                "data_in_exponent_width": self.get_parameter("DATA_IN_0_PRECISION_1"),
+                "data_in_parallelism_dim_1": self.get_parameter(
+                    "DATA_IN_0_PARALLELISM_DIM_1"
+                ),
+                "data_in_parallelism_dim_0": self.get_parameter(
+                    "DATA_IN_0_PARALLELISM_DIM_0"
+                ),
+            },
+            bypass=True
+        )
+
+        # Set verbosity of driver and monitor loggers to debug
+        self.data_in_0_driver.log.setLevel(logging.DEBUG)
+        self.data_out_0_monitor.log.setLevel(logging.DEBUG)
+
+    def preprocess_tensor_for_mxint(self, tensor, config, parallelism):
+        from utils import block_mxint_quant
+        from utils import pack_tensor_to_mx_listed_chunk
+
+        (qtensor, mtensor, etensor) = block_mxint_quant(tensor, config, parallelism)
+        self.log.info(f"Mantissa Tensor: {mtensor}")
+        self.log.info(f"Exponenr Tensor: {etensor}")
+        tensor_inputs = pack_tensor_to_mx_listed_chunk(mtensor, etensor, parallelism)
+        return tensor_inputs
+
+    def generate_inputs(self):
+        return torch.randn(
+            (
+                self.get_parameter("DATA_IN_0_TENSOR_SIZE_DIM_1"),
+                self.get_parameter("DATA_IN_0_TENSOR_SIZE_DIM_0"),
+            )
+        )
+
+    async def run_test(self, us):
+        await self.reset()
+        self.log.info(f"Reset finished")
+        self.data_out_0_monitor.ready.value = 1
+
+        inputs = self.generate_inputs()
+        exp_out = self.model(inputs)
+
+        # * Load the inputs driver
+        self.log.info(f"Processing inputs: {inputs}")
+        inputs = self.preprocess_tensor_for_mxint(
+            tensor=inputs,
+            config={
+                "width": self.get_parameter("DATA_IN_0_PRECISION_0"),
+                "exponent_width": self.get_parameter("DATA_IN_0_PRECISION_1"),
+            },
+            parallelism=[
+                self.get_parameter("DATA_IN_0_PARALLELISM_DIM_1"),
+                self.get_parameter("DATA_IN_0_PARALLELISM_DIM_0"),
+            ],
+        )
+        self.data_in_0_driver.load_driver(inputs)
+
+        # * Load the output monitor
+        self.log.info(f"Processing outputs: {exp_out}")
+        outs = self.preprocess_tensor_for_mxint(
+            tensor=exp_out,
+            config={
+                "width": self.get_parameter("DATA_IN_0_PRECISION_0"),
+                "exponent_width": self.get_parameter("DATA_IN_0_PRECISION_1"),
+            },
+            parallelism=[
+                self.get_parameter("DATA_IN_0_PARALLELISM_DIM_1"),
+                self.get_parameter("DATA_IN_0_PARALLELISM_DIM_0"),
+            ],
+        )
+        self.data_out_0_monitor.load_monitor(outs)
+
+        await Timer(us, units="us")
+        assert self.data_out_0_monitor.exp_queue.empty()
+
+
+@cocotb.test()
+async def cocotb_test(dut):
+    tb = MXIntReluTB(dut)
+    await tb.run_test(us=100)
+
+def get_relu_config(kwargs={}):
+    config = {
+        "DATA_IN_0_TENSOR_SIZE_DIM_0": 2,
+        "DATA_IN_0_TENSOR_SIZE_DIM_1": 2,
+        "DATA_IN_0_PARALLELISM_DIM_0": 2,
+        "DATA_IN_0_PARALLELISM_DIM_1": 1,
+    }
+
+    config.update(kwargs)
+    return config
+
+@pytest.mark.dev
+def test_relu():
+    """
+    More extensive tests to check realistic parameter sizes.
+    """
+    mase_runner(
+        trace=True,
+        module_param_list=[
+            get_relu_config(
+                {
+                    "DATA_IN_0_TENSOR_SIZE_DIM_0": 4,
+                    "DATA_IN_0_PARALLELISM_DIM_0": 2,
+                }
+            ),
+        ],
+    )
+
+if __name__ == "__main__":
+    test_relu()

--- a/src/mase_components/linear_layers/mxint_operators/test/utils.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/utils.py
@@ -8,20 +8,17 @@ from torch import Tensor
 
 def mxint_quantize(x, width: int = 12, exponent_width: int = 6, exponent: int = None):
     """
-    - Convert IEEE FP32/64 to Microsoft floating point (MSFP), where an exponent is shared over all elements in a block.
-    - `e_shared x [(-1)^s1 x mantissa1, (-1)^s2 x mantissa2, ...]`
-    - See https://proceedings.neurips.cc/paper/2020/file/747e32ab0fea7fbd2ad9ec03daa3f840-Paper.pdf
+    - Convert IEEE FP32/64 to Microscaling Interger (MXINT), where an exponent is shared over all elements in a block.
+    - https://arxiv.org/pdf/2310.10537.pdf
+    - https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 
     ---
-    - forward: convert IEEE FP32/64 to MSFP
+    - forward: convert IEEE FP32/64 to MXINT
     - backward: STE
 
     ---
     - `width`: The number of mantissa bits + 1 (the sign bit)
-    - `exponent_width`: the number of exponent bits, which is shared over a block
-    - `exponent_bias`: the exponent bias, if None, `2**(exponent_bits-1)-1` will be used
-    - `block_size`: a list of integers where each integer is the block size on that dimension. See function `block`.
-
+    - `exponent_width`: the number of exponent bits
     """
 
     exponent_bias = 2 ** (exponent_width - 1) - 1
@@ -190,7 +187,7 @@ class MXIntLinear(_LinearBase):
 
 
 class MXIntRelu(relu._ReLUBase):
-    def __init__(self, inplace: bool = False, config = None, bypass = False):
+    def __init__(self, inplace: bool = False, config=None, bypass=False):
         assert config is not None, "config is None!"
         super().__init__(inplace)
 


### PR DESCRIPTION
This pull request introduces a new module `mxint_relu` and its corresponding testbench in the `mase_components` package. The changes include updates to dependencies, the module implementation, its testbench, and utility functions to support the new module.

### New Module Implementation:
* [`src/mase_components/linear_layers/mxint_operators/rtl/mxint_relu.sv`](diffhunk://#diff-af1717bd77e51eaad6b0ad1eebb35e109cda56a881451857f20fb2262e6023c4R1-R74): Added a new Verilog module `mxint_relu` that performs the ReLU operation on input data. This module includes parameter definitions, input/output ports, and the implementation of the ReLU logic.

### Testbench for New Module:
* [`src/mase_components/linear_layers/mxint_operators/test/mxint_relu_tb.py`](diffhunk://#diff-7711c39e6c3e6f4a8f1b14ca4a05908116bea44258992716e9a89ac22f4996d7R1-R164): Added a new testbench for the `mxint_relu` module using Cocotb. This testbench includes the setup for input drivers, output monitors, and the test logic to verify the module's functionality.

### Dependency Updates:
* [`src/mase_components/deps.py`](diffhunk://#diff-56cf872b89af811c598f7fb69ba4eea375bc3318a58441cb2b1ccebefd0c4079R281-R287): Updated the dependencies to include the new `mxint_relu` module and its related components.

### Utility Functions:
* [`src/mase_components/linear_layers/mxint_operators/test/utils.py`](diffhunk://#diff-4de27a927efc816403e0c6e71697d4546a58d8ffd9610efc20a2c0fbcee5c157R3-R21): Updated utility functions to support the new `mxint_relu` module, including the addition of the `MXIntRelu` class which wraps the ReLU operation with quantization support. [[1]](diffhunk://#diff-4de27a927efc816403e0c6e71697d4546a58d8ffd9610efc20a2c0fbcee5c157R3-R21) [[2]](diffhunk://#diff-4de27a927efc816403e0c6e71697d4546a58d8ffd9610efc20a2c0fbcee5c157R187-R220)