### PR TITLE
Fix mxint cast (for the last time)

### DIFF
--- a/src/mase_cocotb/runner.py
+++ b/src/mase_cocotb/runner.py
@@ -45,8 +45,8 @@ def _verilator_args(hierarchical, trace):
         "--stats",
         # Hierarchical
         *(["--hierarchical"] if hierarchical else []),
-        # Signal trace in dump.fst
-        *(["--trace-fst", "--trace-structs"] if trace else []),
+        # Signal trace in dump.vcd
+        *(["--trace", "--trace-structs"] if trace else []),
         "-O2",
         "-build-jobs",
         "8",
@@ -117,6 +117,7 @@ def _single_test(
             # Do not use params in hierarchical verilation
             parameters=module_params if not hierarchical else {},
             build_dir=test_work_dir,
+            waves=trace,
         )
     try:
         runner.test(
@@ -126,6 +127,7 @@ def _single_test(
             seed=seed,
             results_xml="results.xml",
             build_dir=test_work_dir,
+            waves=trace,
         )
         num_tests, fail = get_results(test_work_dir.joinpath("results.xml"))
     except Exception as e:
@@ -317,6 +319,7 @@ def simulate_pass(
         ],
         parameters=module_params,
         build_dir=sim_dir,
+        waves=trace,
     )
     runner.test(
         hdl_toplevel="top",

--- a/src/mase_cocotb/runner.py
+++ b/src/mase_cocotb/runner.py
@@ -45,8 +45,8 @@ def _verilator_args(hierarchical, trace):
         "--stats",
         # Hierarchical
         *(["--hierarchical"] if hierarchical else []),
-        # Signal trace in dump.vcd
-        *(["--trace", "--trace-structs"] if trace else []),
+        # Signal trace in dump.fst
+        *(["--trace-fst", "--trace-structs"] if trace else []),
         "-O2",
         "-build-jobs",
         "8",
@@ -117,7 +117,6 @@ def _single_test(
             # Do not use params in hierarchical verilation
             parameters=module_params if not hierarchical else {},
             build_dir=test_work_dir,
-            waves=trace,
         )
     try:
         runner.test(
@@ -127,7 +126,6 @@ def _single_test(
             seed=seed,
             results_xml="results.xml",
             build_dir=test_work_dir,
-            waves=trace,
         )
         num_tests, fail = get_results(test_work_dir.joinpath("results.xml"))
     except Exception as e:
@@ -319,7 +317,6 @@ def simulate_pass(
         ],
         parameters=module_params,
         build_dir=sim_dir,
-        waves=trace,
     )
     runner.test(
         hdl_toplevel="top",

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -133,10 +133,11 @@ module mxint_cast #(
 
   assign edata_out_full = log2_max_value - IN_MAN_WIDTH + 2 + ebuffer_data_for_out - EBIAS_IN + EBIAS_OUT;
 
-
   always_comb begin
 
-    if (edata_out_full >= (1 << OUT_EXP_WIDTH)) edata_out = (1 << OUT_EXP_WIDTH) - 1;
+    if (log2_max_value == 0) edata_out = 0;
+
+    else if (edata_out_full >= (1 << OUT_EXP_WIDTH)) edata_out = (1 << OUT_EXP_WIDTH) - 1;
 
     else if (edata_out_full < 0) edata_out = 0;
 
@@ -148,14 +149,24 @@ module mxint_cast #(
   // Compute Shift Value
   // =============================
 
-  localparam SHIFT_WIDTH = max(LOSSLESSS_EDATA_WIDTH, IN_MAN_WIDTH, OUT_MAN_WIDTH) + 1;
+  localparam SHIFT_WIDTH = max(LOSSLESSS_EDATA_WIDTH, OUT_MAN_WIDTH, 0);
   logic signed [SHIFT_WIDTH - 1:0] shift_value;
+  logic [IN_MAN_WIDTH - 1:0] max_value;
 
-  assign shift_value = $signed(
-      edata_out_full - edata_out
-  ) + $signed(
-      OUT_MAN_WIDTH - log2_max_value - 2
-  );
+  always_comb begin
+
+    shift_value = $signed(
+          edata_out_full - edata_out
+      ) + $signed(
+          OUT_MAN_WIDTH - log2_max_value - 2
+      );
+
+    max_value = (1 << (OUT_MAN_WIDTH - shift_value - 1));
+
+    if (max_value == 0)
+      max_value = 2 ** (IN_MAN_WIDTH) - 1;
+
+  end
 
   // =============================
   // Compute Output Mantissa
@@ -165,29 +176,51 @@ module mxint_cast #(
 
     always_comb begin
 
-      if (mbuffer_data_for_out[i] == 0) mdata_out[i] = 0;
+      if (mbuffer_data_for_out[i] == 0)
+        mdata_out[i] = 0;
 
-      else if (shift_value > OUT_MAN_WIDTH)
-        if (mbuffer_data_for_out[i] < 0) mdata_out[i] = MIN_DATA_OUT;
-        else mdata_out[i] = MAX_DATA_OUT;
+      else if ((shift_value > 0) && (shift_value >= OUT_MAN_WIDTH))
+        if (mbuffer_data_for_out[i] < 0)
+          mdata_out[i] = MIN_DATA_OUT;
+        else
+          mdata_out[i] = MAX_DATA_OUT;
 
-      else if (shift_value < -IN_MAN_WIDTH)
-        if (mbuffer_data_for_out[i] < 0) mdata_out[i] = -1;
-        else mdata_out[i] = 0;
-
-      else if (mbuffer_data_for_out[i] >= (1 << (OUT_MAN_WIDTH - shift_value - 1)))
+      // This is really stupid, but system verilog has poor support for signed arithmetic of large numbers
+      // So -shift_value != twos_complement(shift_value) hence:
+      else if ((shift_value < 0) && (twos_complement(shift_value) >= IN_MAN_WIDTH))
+        if (mbuffer_data_for_out[i] < 0)
+          mdata_out[i] = -1;
+        else
+          mdata_out[i] = 0;
+        
+      else if ((mbuffer_data_for_out[i] > 0) && (mbuffer_data_for_out[i] > max_value))
         mdata_out[i] = MAX_DATA_OUT;
 
-      else if (-mbuffer_data_for_out[i] >= (1 << (OUT_MAN_WIDTH - shift_value - 1)))
+      else if ((mbuffer_data_for_out[i] < 0) && (twos_complement(mbuffer_data_for_out[i]) > max_value))
         mdata_out[i] = MIN_DATA_OUT;
 
-      else if (shift_value >= 0) mdata_out[i] = mbuffer_data_for_out[i] <<< shift_value;
+      else if (shift_value >= 0)
+        mdata_out[i] = mbuffer_data_for_out[i] <<< shift_value;
 
-      else mdata_out[i] = mbuffer_data_for_out[i] >>> -shift_value;
+      else
+        mdata_out[i] = mbuffer_data_for_out[i] >>> twos_complement(shift_value);
 
     end
 
   end
+
+  // =============================
+  // two's complement
+  // =============================
+
+  localparam TWOS_COMPLEMENT_WIDTH = max(IN_MAN_WIDTH, SHIFT_WIDTH, 0);
+
+  function [TWOS_COMPLEMENT_WIDTH - 1:0] twos_complement;
+    input [TWOS_COMPLEMENT_WIDTH - 1:0] x;
+    begin
+      twos_complement = ~x + 1;
+    end
+  endfunction
 
 endmodule
 
@@ -201,3 +234,4 @@ function [31:0] max;
     max = (x > y && x > z) ? x : (y > z) ? y : z;
   end
 endfunction
+

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -30,6 +30,21 @@ module mxint_cast #(
 );
 
   // =============================
+  // Check Parameters
+  // =============================
+
+  initial begin
+    assert (IN_EXP_WIDTH > 2)
+    else $fatal("IN_EXP_WIDTH must be greater than 2");
+    assert (IN_MAN_WIDTH > 2)
+    else $fatal("IN_EXP_WIDTH must be greater than 2");
+    assert (OUT_MAN_WIDTH > 2)
+    else $fatal("IN_EXP_WIDTH must be greater than 2");
+    assert (OUT_EXP_WIDTH > 2)
+    else $fatal("OUT_EXP_WIDTH must be greater than 2");
+  end
+
+  // =============================
   // Internal Signals
   // =============================
 

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -155,16 +155,11 @@ module mxint_cast #(
 
   always_comb begin
 
-    shift_value = $signed(
-          edata_out_full - edata_out
-      ) + $signed(
-          OUT_MAN_WIDTH - log2_max_value - 2
-      );
+    shift_value = $signed(edata_out_full - edata_out) + $signed(OUT_MAN_WIDTH - log2_max_value - 2);
 
     max_value = (1 << (OUT_MAN_WIDTH - shift_value - 1));
 
-    if (max_value == 0)
-      max_value = 2 ** (IN_MAN_WIDTH - 1);
+    if (max_value == 0) max_value = 2 ** (IN_MAN_WIDTH - 1);
 
   end
 
@@ -176,34 +171,29 @@ module mxint_cast #(
 
     always_comb begin
 
-      if (mbuffer_data_for_out[i] == 0)
-        mdata_out[i] = 0;
+      if (mbuffer_data_for_out[i] == 0) mdata_out[i] = 0;
 
       else if ((shift_value > 0) && (shift_value >= OUT_MAN_WIDTH))
-        if (mbuffer_data_for_out[i] < 0)
-          mdata_out[i] = MIN_DATA_OUT;
-        else
-          mdata_out[i] = MAX_DATA_OUT;
+        if (mbuffer_data_for_out[i] < 0) mdata_out[i] = MIN_DATA_OUT;
+        else mdata_out[i] = MAX_DATA_OUT;
 
       // This is really stupid, but system verilog has poor support for signed arithmetic of large numbers
       // So -shift_value != twos_complement(shift_value) hence:
       else if ((shift_value < 0) && (twos_complement(shift_value) >= IN_MAN_WIDTH))
-        if (mbuffer_data_for_out[i] < 0)
-          mdata_out[i] = -1;
-        else
-          mdata_out[i] = 0;
-        
+        if (mbuffer_data_for_out[i] < 0) mdata_out[i] = -1;
+        else mdata_out[i] = 0;
+
       else if ((mbuffer_data_for_out[i] > 0) && (mbuffer_data_for_out[i] >= max_value))
         mdata_out[i] = MAX_DATA_OUT;
 
-      else if ((mbuffer_data_for_out[i] < 0) && (twos_complement(mbuffer_data_for_out[i]) >= max_value))
+      else if ((mbuffer_data_for_out[i] < 0) && (twos_complement(
+              mbuffer_data_for_out[i]
+          ) >= max_value))
         mdata_out[i] = MIN_DATA_OUT;
 
-      else if (shift_value >= 0)
-        mdata_out[i] = mbuffer_data_for_out[i] <<< shift_value;
+      else if (shift_value >= 0) mdata_out[i] = mbuffer_data_for_out[i] <<< shift_value;
 
-      else
-        mdata_out[i] = mbuffer_data_for_out[i] >>> twos_complement(shift_value);
+      else mdata_out[i] = mbuffer_data_for_out[i] >>> twos_complement(shift_value);
 
     end
 

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -36,12 +36,12 @@ module mxint_cast #(
   initial begin
     assert (IN_EXP_WIDTH > 2)
     else $fatal("IN_EXP_WIDTH must be greater than 2");
-    assert (IN_MAN_WIDTH > 2)
-    else $fatal("IN_EXP_WIDTH must be greater than 2");
-    assert (OUT_MAN_WIDTH > 2)
+    assert (IN_MAN_WIDTH > 3)
     else $fatal("IN_EXP_WIDTH must be greater than 2");
     assert (OUT_EXP_WIDTH > 2)
     else $fatal("OUT_EXP_WIDTH must be greater than 2");
+    assert (OUT_MAN_WIDTH > 3)
+    else $fatal("IN_EXP_WIDTH must be greater than 2");
   end
 
   // =============================

--- a/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
+++ b/src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv
@@ -164,7 +164,7 @@ module mxint_cast #(
     max_value = (1 << (OUT_MAN_WIDTH - shift_value - 1));
 
     if (max_value == 0)
-      max_value = 2 ** (IN_MAN_WIDTH) - 1;
+      max_value = 2 ** (IN_MAN_WIDTH - 1);
 
   end
 
@@ -193,10 +193,10 @@ module mxint_cast #(
         else
           mdata_out[i] = 0;
         
-      else if ((mbuffer_data_for_out[i] > 0) && (mbuffer_data_for_out[i] > max_value))
+      else if ((mbuffer_data_for_out[i] > 0) && (mbuffer_data_for_out[i] >= max_value))
         mdata_out[i] = MAX_DATA_OUT;
 
-      else if ((mbuffer_data_for_out[i] < 0) && (twos_complement(mbuffer_data_for_out[i]) > max_value))
+      else if ((mbuffer_data_for_out[i] < 0) && (twos_complement(mbuffer_data_for_out[i]) >= max_value))
         mdata_out[i] = MIN_DATA_OUT;
 
       else if (shift_value >= 0)

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -124,10 +124,10 @@ def get_mxint_cast_config_random(seed, kwargs={}):
     MAX_EXPONENT = 6
 
     in_man = random.randint(3, MAX_MANTISSA)
-    in_exp = random.randint(3, MAX_EXPONENT)
+    in_exp = random.randint(2, MAX_EXPONENT)
 
     out_man = random.randint(3, MAX_MANTISSA)
-    out_exp = random.randint(3, MAX_EXPONENT)
+    out_exp = random.randint(2, MAX_EXPONENT)
 
     config = {
         "IN_MAN_WIDTH": in_man,

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -120,13 +120,13 @@ def get_mxint_cast_config_random(seed, kwargs={}):
 
     BLOCK_SIZE = random.randint(1, 16)
 
-    MAX_MANTISSA = 16
+    MAX_MANTISSA = 32
     MAX_EXPONENT = 6
 
-    in_man = random.randint(4, MAX_MANTISSA)
+    in_man = random.randint(2, MAX_MANTISSA)
     in_exp = random.randint(2, MAX_EXPONENT)
 
-    out_man = random.randint(4, MAX_MANTISSA)
+    out_man = random.randint(2, MAX_MANTISSA)
     out_exp = random.randint(2, MAX_EXPONENT)
 
     config = {
@@ -151,12 +151,12 @@ def test_mxint_cast_random():
 
     # use this to fix a particular parameter value
     param_override = {
-        # "IN_MAN_WIDTH": 10,
-        # "IN_EXP_WIDTH": 5,
-        # "OUT_MAN_WIDTH": 10,
-        # "OUT_EXP_WIDTH": 5,
-        # "BLOCK_SIZE": 4,
-    }
+            # "IN_MAN_WIDTH": 32,
+            # "IN_EXP_WIDTH": 6,
+            # "OUT_MAN_WIDTH": 6,
+            # "OUT_EXP_WIDTH": 3,
+            # "BLOCK_SIZE": 2,
+        }
 
     if seed is not None:
         seed = int(seed)

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -123,11 +123,11 @@ def get_mxint_cast_config_random(seed, kwargs={}):
     MAX_MANTISSA = 32
     MAX_EXPONENT = 6
 
-    in_man = random.randint(2, MAX_MANTISSA)
-    in_exp = random.randint(2, MAX_EXPONENT)
+    in_man = random.randint(3, MAX_MANTISSA)
+    in_exp = random.randint(3, MAX_EXPONENT)
 
-    out_man = random.randint(2, MAX_MANTISSA)
-    out_exp = random.randint(2, MAX_EXPONENT)
+    out_man = random.randint(3, MAX_MANTISSA)
+    out_exp = random.randint(3, MAX_EXPONENT)
 
     config = {
         "IN_MAN_WIDTH": in_man,

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_cast_tb.py
@@ -151,12 +151,12 @@ def test_mxint_cast_random():
 
     # use this to fix a particular parameter value
     param_override = {
-            # "IN_MAN_WIDTH": 32,
-            # "IN_EXP_WIDTH": 6,
-            # "OUT_MAN_WIDTH": 6,
-            # "OUT_EXP_WIDTH": 3,
-            # "BLOCK_SIZE": 2,
-        }
+        # "IN_MAN_WIDTH": 32,
+        # "IN_EXP_WIDTH": 6,
+        # "OUT_MAN_WIDTH": 6,
+        # "OUT_EXP_WIDTH": 3,
+        # "BLOCK_SIZE": 2,
+    }
 
     if seed is not None:
         seed = int(seed)

--- a/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
+++ b/src/mase_components/linear_layers/mxint_operators/test/mxint_linear_tb.py
@@ -235,7 +235,7 @@ def get_mxint_linear_config_random(seed, kwargs={}):
     MAX_MANTISSA = 16
     MAX_EXPONENT = 6
 
-    mantissas = [random.randint(3, MAX_MANTISSA)] * 4
+    mantissas = [random.randint(4, MAX_MANTISSA)] * 4
     exps = [random.randint(3, min(mantissas[0], MAX_EXPONENT))] * 4
 
     config = {


### PR DESCRIPTION
This pull request includes several changes to the `mxint_cast` module in the `src/mase_components/linear_layers/mxint_operators/rtl/mxint_cast.sv` file and updates to the corresponding test file `mxint_cast_tb.py`. The changes aim to improve the handling of edge cases, enhance the accuracy of calculations, and update test parameters.

### Improvements to edge case handling and accuracy:

* Added a condition to handle the case where `log2_max_value` is zero in the computation of `edata_out` to avoid potential errors.
* Updated the calculation of `shift_value` and introduced `max_value` to ensure accurate handling of large numbers and edge cases.
* Introduced a two's complement function to handle signed arithmetic more effectively and updated conditions for `mdata_out` to use this function.

### Test parameter updates:

* Increased `MAX_MANTISSA` from 16 to 32 and adjusted the range for `in_man` and `out_man` in the `get_mxint_cast_config_random` function to allow for a wider range of test cases.
* Updated the parameter overrides in the `test_mxint_cast_random` function to reflect the new maximum values for mantissa and exponent widths.